### PR TITLE
Fix first() throwing Bad State: No Element

### DIFF
--- a/lib/src/objectdb_base.dart
+++ b/lib/src/objectdb_base.dart
@@ -366,9 +366,9 @@ class ObjectDB {
         return this._data.where(match).toList();
       }
       if (filter == Filter.first) {
-        return this._data.firstWhere(match);
+        return this._data.firstWhere(match, orElse: () => null);
       } else {
-        return this._data.lastWhere(match);
+        return this._data.lastWhere(match, orElse: () => null);
       }
     }));
   }


### PR DESCRIPTION
When `first()` method is used, it might throw Bad State if there is no such data. Because `firstWhere()` and `lastWhere()` don't return null when there is no item in list, the problem is caused in `_find()` function.

### Related Issues
fixed #18